### PR TITLE
Add reno

### DIFF
--- a/releasenotes/notes/pypi-release-3e4d5ceb7b6e252a.yaml
+++ b/releasenotes/notes/pypi-release-3e4d5ceb7b6e252a.yaml
@@ -1,0 +1,7 @@
+---
+prelude: >
+    This is the first PyPI release of this XBlock.
+other:
+  - |
+    This project now uses reno (https://pypi.org/project/reno/) to
+    manage its changelog and release notes.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,0 +1,2 @@
+# Requirements for development
+reno


### PR DESCRIPTION
Manage release notes with reno.

To create or edit release notes, run `pip install reno` (or `pip install -r requirements/dev.txt`) in your development environment.

Then, to create a new release note, run:

```
reno new <slug>
```

To edit a release note with the currently set EDITOR:

```
reno edit <slug>
```

To create a report comprising the release notes since the beginning:

```
reno report .
```